### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix WebSocket authentication bypass vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-06 - Insecure WebSocket User Impersonation
+**Vulnerability:** The WebSocket endpoint for the chat service allowed connections to bypass JWT authentication by supplying a `userId` query parameter. This insecure fallback was enabled globally by default, allowing attackers to impersonate any user in production.
+**Learning:** Development convenience features (like insecure auth fallbacks) must never default to true globally. Relying on explicit disable flags (`ALLOW_INSECURE_WS_USER_ID === "false"`) is dangerous as missing environment variables lead to insecure defaults.
+**Prevention:** Always default development backdoors to `false` in production by checking `process.env.NODE_ENV !== "production"`.

--- a/elyrii_server/modules/chat/chat.controller.ts
+++ b/elyrii_server/modules/chat/chat.controller.ts
@@ -19,7 +19,7 @@ const allowInsecureWsUserIdFallback =
         ? true
         : Bun.env.ALLOW_INSECURE_WS_USER_ID === "false"
             ? false
-            : true; // Default to true for ease of development
+            : Bun.env.NODE_ENV !== "production"; // Default to true only in non-production environments
 
 console.log(`[Chat] Insecure WS userId fallback enabled: ${allowInsecureWsUserIdFallback}`);
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The WebSocket endpoint in `chat.controller.ts` allowed bypassing authentication by providing a `userId` query parameter. This development fallback was enabled by default even in production, allowing attackers to impersonate any user.
🎯 Impact: Attackers could connect to the chat WebSocket as any user, viewing their chat history and sending messages on their behalf.
🔧 Fix: Updated `allowInsecureWsUserIdFallback` to default to `false` in production environments by checking `Bun.env.NODE_ENV !== "production"`.
✅ Verification: Ran test suite (`bun test`) which confirmed the changes are safe. Production environments will now block connections using the `userId` query parameter unless explicitly enabled.

---
*PR created automatically by Jules for task [13943227512597745568](https://jules.google.com/task/13943227512597745568) started by @Rafael-Sapalo*