### PR TITLE
feat(gamification): add AI challenge proposals section

### DIFF
--- a/elyrii_app/lib/features/gamification/presentation/pages/challenges_page.dart
+++ b/elyrii_app/lib/features/gamification/presentation/pages/challenges_page.dart
@@ -9,6 +9,7 @@ import '../widgets/level_progress_header.dart';
 import '../widgets/daily_streak_card.dart';
 import '../widgets/quest_tile.dart';
 import '../widgets/challenge_card.dart';
+import '../widgets/ai_proposal_card.dart';
 import '../widgets/badges_grid.dart';
 
 class ChallengesPage extends StatefulWidget {
@@ -21,6 +22,7 @@ class ChallengesPage extends StatefulWidget {
 class _ChallengesPageState extends State<ChallengesPage> {
   // Suivi du défi en cours de démarrage (pour spinner local)
   String? _startingChallengeId;
+  String? _processingProposalId;
 
   // Badges mockés (pas encore de backend pour ça)
   final List<BadgeItem> _badges = [
@@ -76,6 +78,18 @@ class _ChallengesPageState extends State<ChallengesPage> {
     if (mounted) setState(() => _startingChallengeId = null);
   }
 
+  Future<void> _handleAcceptProposal(String proposalId) async {
+    setState(() => _processingProposalId = proposalId);
+    await context.read<GamificationProvider>().acceptChallenge(proposalId);
+    if (mounted) setState(() => _processingProposalId = null);
+  }
+
+  Future<void> _handleRejectProposal(String proposalId) async {
+    setState(() => _processingProposalId = proposalId);
+    await context.read<GamificationProvider>().rejectChallenge(proposalId);
+    if (mounted) setState(() => _processingProposalId = null);
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -127,6 +141,21 @@ class _ChallengesPageState extends State<ChallengesPage> {
                       ),
 
                       const SizedBox(height: 32),
+
+                      // ── Propositions IA ────────────────────────────
+                      if (provider.proposals.isNotEmpty) ...[
+                        _sectionTitle(context, 'Propositions IA', isDark),
+                        const SizedBox(height: 12),
+                        ...provider.proposals.map(
+                          (proposal) => AiProposalCard(
+                            proposal: proposal,
+                            isProcessing: _processingProposalId == proposal.id,
+                            onAccept: () => _handleAcceptProposal(proposal.id),
+                            onReject: () => _handleRejectProposal(proposal.id),
+                          ),
+                        ),
+                        const SizedBox(height: 24),
+                      ],
 
                       // ── Défis disponibles ──────────────────────────
                       if (provider.availableChallenges.isNotEmpty) ...[

--- a/elyrii_app/lib/features/gamification/presentation/widgets/ai_proposal_card.dart
+++ b/elyrii_app/lib/features/gamification/presentation/widgets/ai_proposal_card.dart
@@ -1,0 +1,152 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_animate/flutter_animate.dart';
+import '../../../../core/theme/app_colors.dart';
+import '../../../../core/widgets/glass/liquid_glass_card.dart';
+import '../../data/models/gamification_models.dart';
+
+class AiProposalCard extends StatelessWidget {
+  final UserChallenge proposal;
+  final bool isProcessing;
+  final VoidCallback onAccept;
+  final VoidCallback onReject;
+
+  const AiProposalCard({
+    super.key,
+    required this.proposal,
+    required this.onAccept,
+    required this.onReject,
+    this.isProcessing = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: LiquidGlassCard(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                // Icône
+                Container(
+                  padding: const EdgeInsets.all(12),
+                  decoration: BoxDecoration(
+                    color: Colors.purpleAccent.withValues(alpha: 0.12),
+                    shape: BoxShape.circle,
+                    border: Border.all(
+                      color: Colors.purpleAccent.withValues(alpha: 0.25),
+                      width: 1,
+                    ),
+                  ),
+                  child: Icon(
+                    proposal.displayIcon,
+                    color: Colors.purpleAccent,
+                    size: 20,
+                  ),
+                ),
+                const SizedBox(width: 16),
+
+                // Titre + badge IA
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        children: [
+                          Expanded(
+                            child: Text(
+                              proposal.displayTitle,
+                              style: TextStyle(
+                                fontSize: 15,
+                                fontWeight: FontWeight.w600,
+                                color: isDark
+                                    ? AppColors.textPrimaryDark
+                                    : AppColors.textPrimaryLight,
+                              ),
+                            ),
+                          ),
+                          Container(
+                            padding: const EdgeInsets.symmetric(
+                                horizontal: 6, vertical: 2),
+                            decoration: BoxDecoration(
+                              color: Colors.purpleAccent.withValues(alpha: 0.2),
+                              borderRadius: BorderRadius.circular(8),
+                            ),
+                            child: const Text(
+                              'IA',
+                              style: TextStyle(
+                                fontSize: 10,
+                                fontWeight: FontWeight.bold,
+                                color: Colors.purpleAccent,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                      if (proposal.displayDescription.isNotEmpty) ...[
+                        const SizedBox(height: 4),
+                        Text(
+                          proposal.displayDescription,
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                          style: TextStyle(
+                            fontSize: 12,
+                            color: isDark
+                                ? AppColors.textTertiaryDark
+                                : AppColors.textTertiaryLight,
+                          ),
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            // Actions
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                if (isProcessing)
+                  const SizedBox(
+                    width: 24,
+                    height: 24,
+                    child: CircularProgressIndicator(
+                      strokeWidth: 2,
+                      color: Colors.purpleAccent,
+                    ),
+                  )
+                else ...[
+                  TextButton(
+                    onPressed: onReject,
+                    style: TextButton.styleFrom(
+                      foregroundColor: AppColors.error,
+                    ),
+                    child: const Text('Refuser'),
+                  ),
+                  const SizedBox(width: 8),
+                  ElevatedButton(
+                    onPressed: onAccept,
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Colors.purpleAccent,
+                      foregroundColor: Colors.white,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(20),
+                      ),
+                    ),
+                    child: const Text('Accepter'),
+                  ),
+                ],
+              ],
+            ),
+          ],
+        ),
+      ),
+    ).animate().fadeIn(duration: 250.ms).slideX(begin: 0.05, end: 0);
+  }
+}

--- a/elyrii_app/pubspec.lock
+++ b/elyrii_app/pubspec.lock
@@ -45,10 +45,10 @@ packages:
     dependency: "direct main"
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -372,18 +372,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
@@ -609,10 +609,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.9"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
Adds an AI challenge proposals section to the challenges page so users can review and choose to accept or reject AI-generated challenge suggestions.

---
*PR created automatically by Jules for task [11375861337604116897](https://jules.google.com/task/11375861337604116897) started by @Rafael-Sapalo*