### PR TITLE
🛡️ Sentinel: [MEDIUM] Prevent info leakage in auth error response

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-08 - [Medium] Prevent Information Leakage in Registration Error
+**Vulnerability:** The registration endpoint in `elyrii_server/modules/auth/auth.controller.ts` includes `error: String(error)` in its 500 internal server error response.
+**Learning:** Returning stringified internal errors to the client can leak stack traces, database schema details, or other sensitive internals, providing reconnaissance material to an attacker.
+**Prevention:** Catch blocks should log the detailed error internally but only return a generic error message (e.g., 'registration failed') to the client without exposing the underlying `error` object.

--- a/elyrii_server/modules/auth/auth.controller.ts
+++ b/elyrii_server/modules/auth/auth.controller.ts
@@ -98,7 +98,7 @@ class AuthController {
                 return ctx.json({ message: 'User registered successfully', token: token }, 201);
             } catch (error) {
                 console.error("Registration error details:", error);
-                return ctx.json({ message: 'registration failed', error: String(error) }, 500);
+                return ctx.json({ message: 'registration failed' }, 500);
             }
     })
     


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The registration endpoint in `elyrii_server/modules/auth/auth.controller.ts` exposed internal server error details to clients via `String(error)`.
🎯 **Impact:** Exposing internal error strings or stack traces can provide attackers with insights into the database schema, underlying infrastructure, or the call stack, aiding reconnaissance.
🔧 **Fix:** Sanitized the response by catching and logging the specific error internally, while only returning a generic `message: 'registration failed'` to the client.
✅ **Verification:** Validated the application successfully compiles and passes tests (`bun test`) after the change.

---
*PR created automatically by Jules for task [3896416105089336206](https://jules.google.com/task/3896416105089336206) started by @Rafael-Sapalo*