### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix error details leakage in registration endpoint

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-09 - Remove error leakage on registration
+**Vulnerability:** Error string (`String(error)`) from registration exception was being returned in 500 error response.
+**Learning:** Application error handling occasionally leaked details to clients while correctly logging them internally.
+**Prevention:** Avoid returning raw exception objects or stack trace strings in `ctx.json` across all endpoints; ensure generic fallback messages are used.

--- a/elyrii_server/modules/auth/auth.controller.ts
+++ b/elyrii_server/modules/auth/auth.controller.ts
@@ -98,7 +98,7 @@ class AuthController {
                 return ctx.json({ message: 'User registered successfully', token: token }, 201);
             } catch (error) {
                 console.error("Registration error details:", error);
-                return ctx.json({ message: 'registration failed', error: String(error) }, 500);
+                return ctx.json({ message: 'registration failed' }, 500);
             }
     })
     


### PR DESCRIPTION
🚨 **Severity**: MEDIUM
💡 **Vulnerability**: The registration endpoint returned raw error strings (`String(error)`) in its 500 JSON response on failure, potentially exposing sensitive database or internal application details to the client.
🎯 **Impact**: An attacker could gain insight into the backend architecture, database schemas, or connection details, assisting in further targeted attacks.
🔧 **Fix**: Removed the `error: String(error)` key from the `ctx.json` payload so only a generic "registration failed" message is sent to the client, while keeping the detailed internal `console.error` log intact.
✅ **Verification**: Verified using `bun test` in `elyrii_server` which passed without regressions. Verified the diff shows the `error` field removed from the response.

---
*PR created automatically by Jules for task [18340487409084200896](https://jules.google.com/task/18340487409084200896) started by @Rafael-Sapalo*