### PR TITLE
🛡️ Sentinel: [HIGH] Fix Insecure WebSocket authentication fallback

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2026-05-10 - Insecure WebSocket Authentication Fallback Default
+**Vulnerability:** Chat WebSocket endpoint allowed unauthorized connection and impersonation by using a `?userId=<id>` query parameter fallback that defaulted to `true` globally.
+**Learning:** Hardcoded boolean fallbacks for ease of development can inadvertently introduce authentication bypasses in production. Environmental context (`NODE_ENV`) should be strictly enforced to determine fallback availability.
+**Prevention:** Always default development-only authentication bypasses or fallbacks to `process.env.NODE_ENV !== "production"` rather than raw `true` values.

--- a/elyrii_server/modules/chat/chat.controller.ts
+++ b/elyrii_server/modules/chat/chat.controller.ts
@@ -19,7 +19,7 @@ const allowInsecureWsUserIdFallback =
         ? true
         : Bun.env.ALLOW_INSECURE_WS_USER_ID === "false"
             ? false
-            : true; // Default to true for ease of development
+            : process.env.NODE_ENV !== "production"; // Default to false in production
 
 console.log(`[Chat] Insecure WS userId fallback enabled: ${allowInsecureWsUserIdFallback}`);
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The Chat WebSocket endpoint allowed unauthorized connection by using an insecure user ID query parameter fallback that defaulted to `true` unconditionally.
🎯 Impact: An attacker could bypass authentication and impersonate any user on the WebSocket chat endpoint.
🔧 Fix: Updated the default value of `allowInsecureWsUserIdFallback` to rely on `process.env.NODE_ENV !== "production"`.
✅ Verification: Verify that the fallback is only active when `NODE_ENV` is not `production` or when explicitly enabled via `ALLOW_INSECURE_WS_USER_ID`.

---
*PR created automatically by Jules for task [1250359348605138400](https://jules.google.com/task/1250359348605138400) started by @Rafael-Sapalo*