### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Information Disclosure in Auth

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-11 - [Raw Errors in HTTP Responses]
+**Vulnerability:** Information Disclosure
+**Learning:** Found stringified errors (`String(error)`) being directly sent to the client in HTTP responses, like `return ctx.json({ error: String(error) }, 500);` during user registration. This exposes internal stack traces or database errors to end users, presenting an information disclosure vulnerability.
+**Prevention:** Avoid stringifying errors and returning them in HTTP responses. Always log raw errors internally (`console.error(...)`) and return a generic error message, such as `Registration failed`, to the client instead. When rethrowing errors in repositories, simply throw `error` instead of `new Error(String(error))` to ensure the original error structure isn't lost.

--- a/elyrii_server/modules/auth/auth.controller.ts
+++ b/elyrii_server/modules/auth/auth.controller.ts
@@ -77,7 +77,7 @@ class AuthController {
                 });
                 
                 if (!newUser) {
-                    return ctx.json({ message: 'registration failed' }, 500);
+                    return ctx.json({ error: 'Registration failed' }, 500);
                 }
 
                 if (this.requireEmailVerification) {
@@ -98,7 +98,7 @@ class AuthController {
                 return ctx.json({ message: 'User registered successfully', token: token }, 201);
             } catch (error) {
                 console.error("Registration error details:", error);
-                return ctx.json({ message: 'registration failed', error: String(error) }, 500);
+                return ctx.json({ error: 'Registration failed' }, 500);
             }
     })
     

--- a/elyrii_server/repository/auth.repository.ts
+++ b/elyrii_server/repository/auth.repository.ts
@@ -30,7 +30,7 @@ class AuthRepository {
             
             return newUser[0];
         } catch (error) {
-            throw new Error(error instanceof Error ? error.message : String(error));
+            throw error;
         }
     }
 

--- a/elyrii_server/repository/token.repository.ts
+++ b/elyrii_server/repository/token.repository.ts
@@ -12,7 +12,7 @@ class TokenRepository {
                 device: device,
             })
         } catch (error) {
-            throw new Error(error instanceof Error ? error.message : String(error));
+            throw error;
         }
     }
     


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix Information Disclosure in Auth

🚨 Severity: MEDIUM
💡 Vulnerability: The `register` endpoint was catching exceptions and sending the raw `String(error)` in the JSON response payload. Similar patterns were used when throwing exceptions in `auth.repository.ts` and `token.repository.ts`.
🎯 Impact: Sending raw application errors directly to clients leaks internal implementation details (such as database type, schema internals, or query syntax), which violates defense in depth and fail securely principles.
🔧 Fix:
- Modified the auth controller to return a generic "Registration failed" error to the client while keeping the internal log containing the original error details.
- Cleaned up the error rethrowing in `auth.repository.ts` and `token.repository.ts` to throw the raw error object rather than obfuscating the stack trace into a generic Error with a stringified payload.
✅ Verification: Backend unit tests were re-run and pass. Evaluated the commit against security guidelines.

---
*PR created automatically by Jules for task [16559196893058489547](https://jules.google.com/task/16559196893058489547) started by @Rafael-Sapalo*