### PR TITLE
chore(ios): remove redundant keys from Info.plist

### DIFF
--- a/elyrii_app/ios/Runner/Info.plist
+++ b/elyrii_app/ios/Runner/Info.plist
@@ -58,61 +58,6 @@
 					<string>Main</string>
 				</dict>
 			</array>
-		<key>CADisableMinimumFrameDurationOnPhone</key>
-		<true/>
-		<key>CFBundleDevelopmentRegion</key>
-		<string>$(DEVELOPMENT_LANGUAGE)</string>
-		<key>CFBundleDisplayName</key>
-		<string>Elyrii</string>
-		<key>CFBundleExecutable</key>
-		<string>$(EXECUTABLE_NAME)</string>
-		<key>CFBundleIdentifier</key>
-		<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
-		<key>CFBundleInfoDictionaryVersion</key>
-		<string>6.0</string>
-		<key>CFBundleName</key>
-		<string>elyrii_app</string>
-		<key>CFBundlePackageType</key>
-		<string>APPL</string>
-		<key>CFBundleShortVersionString</key>
-		<string>$(FLUTTER_BUILD_NAME)</string>
-		<key>CFBundleSignature</key>
-		<string>????</string>
-		<key>CFBundleVersion</key>
-		<string>$(FLUTTER_BUILD_NUMBER)</string>
-		<key>LSRequiresIPhoneOS</key>
-		<true/>
-		<key>NSCameraUsageDescription</key>
-		<string>Elyrii peut utiliser la caméra pour des fonctionnalités futures.</string>
-		<key>NSMicrophoneUsageDescription</key>
-		<string>Elyrii utilise le microphone pour les fonctionnalités de méditation guidée et d'interaction vocale.</string>
-		<key>NSPhotoLibraryUsageDescription</key>
-		<string>Elyrii peut accéder à votre galerie pour personnaliser votre expérience.</string>
-		<key>NSSpeechRecognitionUsageDescription</key>
-		<string>Elyrii utilise la reconnaissance vocale pour améliorer votre expérience interactive.</string>
-		<key>UIApplicationSupportsIndirectInputEvents</key>
-		<true/>
-		<key>UILaunchStoryboardName</key>
-		<string>LaunchScreen</string>
-		<key>UIMainStoryboardFile</key>
-		<string>Main</string>
-		<key>UIStatusBarHidden</key>
-		<false/>
-		<key>UISupportedInterfaceOrientations</key>
-		<array>
-			<string>UIInterfaceOrientationPortrait</string>
-		</array>
-		<key>UISupportedInterfaceOrientations~ipad</key>
-		<array>
-			<string>UIInterfaceOrientationPortrait</string>
-			<string>UIInterfaceOrientationPortraitUpsideDown</string>
-		</array>
-		<key>io.flutter.embedded_views_preview</key>
-		<true/>
-		<key>NSAppTransportSecurity</key>
-		<dict>
-			<key>NSAllowsArbitraryLoads</key>
-			<true/>
 		</dict>
 	</dict>
 	<key>UIApplicationSupportsIndirectInputEvents</key>


### PR DESCRIPTION
* Delete default CFBundle entries, UI orientation settings, and usage description keys that Flutter now generates automatically.
* Simplify iOS configuration to avoid duplication and potential conflicts with Flutter tooling.